### PR TITLE
Implement cancelAppointment tool

### DIFF
--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -39,3 +39,7 @@ export interface Appointment {
   insuranceName?: string;
   insuranceNumber?: string;
 }
+
+export interface CancelAppointmentRequest {
+  is_status_modified_by_patient: boolean;
+}

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -1,5 +1,12 @@
 import { FastifyInstance } from 'fastify';
-import { scheduleAppointment, ScheduleAppointmentParams } from '../tools/scheduleAppointment';
+import {
+  scheduleAppointment,
+  ScheduleAppointmentParams,
+} from '../tools/scheduleAppointment';
+import {
+  cancelAppointment,
+  CancelAppointmentParams,
+} from '../tools/cancelAppointment';
 import { Appointment } from './schema';
 import { z } from 'zod';
 
@@ -10,7 +17,7 @@ export interface Tool<P, R> {
   execute: (params: P) => Promise<R>;
 }
 
-export const tools: Tool<any, any>[] = [scheduleAppointment];
+export const tools: Tool<any, any>[] = [scheduleAppointment, cancelAppointment];
 
 export function registerToolRoutes(app: FastifyInstance): void {
   app.get('/mcp/tools', async () =>
@@ -26,7 +33,8 @@ export function registerToolRoutes(app: FastifyInstance): void {
     if (!tool) return reply.status(404).send({ error: 'Tool not found' });
     const parsed = tool.parameters.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send(parsed.error);
-    const result = await tool.execute(parsed.data as ScheduleAppointmentParams);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await tool.execute(parsed.data as any);
     return result;
   });
 }

--- a/src/services/huliClient.ts
+++ b/src/services/huliClient.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { CreateAppointmentRequest, Appointment } from '../mcp/schema';
+import { CreateAppointmentRequest, Appointment, CancelAppointmentRequest } from '../mcp/schema';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -50,6 +50,10 @@ class HuliClient {
 
   async createAppointment(data: CreateAppointmentRequest): Promise<Appointment> {
     return this.request<Appointment>({ method: 'POST', url: '/appointment', data });
+  }
+
+  async cancelAppointment(eventId: string, data: CancelAppointmentRequest): Promise<Appointment> {
+    return this.request<Appointment>({ method: 'PUT', url: `/appointment/${eventId}/cancel`, data });
   }
 }
 

--- a/src/tools/cancelAppointment.ts
+++ b/src/tools/cancelAppointment.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { huliClient } from '../services/huliClient';
+import { Appointment, CancelAppointmentRequest } from '../mcp/schema';
+
+export const cancelAppointmentSchema = z.object({
+  event_id: z.string(),
+  is_status_modified_by_patient: z.boolean().optional().default(true),
+});
+
+export type CancelAppointmentParams = z.infer<typeof cancelAppointmentSchema>;
+
+export const cancelAppointment = {
+  name: 'cancelar_cita',
+  description: `Cancels an existing appointment in HuliHealth.
+
+**Best for:** when a patient or provider needs to cancel a booked appointment.
+**Common mistakes:** using for rescheduling (use the reschedule tool instead).
+**Usage Example:**
+\`\`\`json
+{
+  "event_id": "12345",
+  "is_status_modified_by_patient": true
+}
+\`\`\`
+`,
+  parameters: cancelAppointmentSchema,
+  async execute(params: CancelAppointmentParams): Promise<Appointment> {
+    const data: CancelAppointmentRequest = {
+      is_status_modified_by_patient: params.is_status_modified_by_patient,
+    };
+    return huliClient.cancelAppointment(params.event_id, data);
+  },
+};
+export type CancelAppointmentTool = typeof cancelAppointment;

--- a/test/cancelAppointment.spec.ts
+++ b/test/cancelAppointment.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { cancelAppointmentSchema } from '../src/tools/cancelAppointment';
+
+describe('cancelAppointmentSchema', () => {
+  it('validates required fields', () => {
+    const result = cancelAppointmentSchema.safeParse({
+      event_id: '1',
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `cancelAppointment` TypeScript tool
- add request type and API method for cancellation
- register tool in tool registry
- test schema validation for cancel tool

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68704f43a65c8325ae90627e0096e163