### PR TITLE
Refactor MCP server and add tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
+#!/usr/bin/env node
 import Fastify from 'fastify';
 import dotenv from 'dotenv';
-import { tools, registerToolRoutes } from './mcp/toolRegistry.js';
+import {
+  tools,
+  registerToolRoutes,
+} from './mcp/toolRegistry.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -9,7 +13,31 @@ dotenv.config();
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 
-function createMcpServer(): McpServer {
+function validateEnv(): void {
+  if (!process.env.HULIHEALTH_API_KEY || !process.env.HULI_ORG_ID) {
+    throw new Error(
+      'HULIHEALTH_API_KEY and HULI_ORG_ID environment variables must be set'
+    );
+  }
+}
+
+let isStdioTransport = false;
+
+function safeLog(
+  server: McpServer,
+  level: 'info' | 'warning' | 'error' | 'debug' | 'notice',
+  data: unknown
+): void {
+  if (isStdioTransport) {
+    console.error(
+      `[${level}] ${typeof data === 'object' ? JSON.stringify(data) : data}`
+    );
+  } else {
+    server.sendLoggingMessage({ level, data });
+  }
+}
+
+export function createMcpServer(): McpServer {
   const server = new McpServer({ name: 'hulihealth-mcp', version: '1.0.0' });
   for (const tool of tools) {
     server.registerTool(
@@ -19,7 +47,6 @@ function createMcpServer(): McpServer {
         inputSchema: tool.parameters as any,
       },
       async (params) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const result = await tool.execute(params as any);
         return { content: [{ type: 'json', json: result }] };
       }
@@ -28,42 +55,65 @@ function createMcpServer(): McpServer {
   return server;
 }
 
-// Connect stdio transport for CLI usage
-const stdioServer = createMcpServer();
-const stdioTransport = new StdioServerTransport();
-stdioServer.connect(stdioTransport).catch((err) => {
-  console.error('Failed to start stdio transport', err);
-});
+export function buildHttpServer() {
+  const app = Fastify();
+  registerToolRoutes(app);
 
-const app = Fastify();
+  const sseSessions = new Map<
+    string,
+    { server: McpServer; transport: SSEServerTransport }
+  >();
 
-registerToolRoutes(app);
+  app.get('/mcp', async (req, reply) => {
+    const server = createMcpServer();
+    const transport = new SSEServerTransport('/mcp', reply.raw);
+    sseSessions.set(transport.sessionId, { server, transport });
+    transport.onclose = () => sseSessions.delete(transport.sessionId);
+    await server.connect(transport);
+  });
 
-// SSE support
-const sseSessions = new Map<string, { server: McpServer; transport: SSEServerTransport }>();
+  app.post('/mcp', async (req, reply) => {
+    const sessionId = (req.query as any).sessionId as string;
+    const session = sseSessions.get(sessionId);
+    if (!session) {
+      reply.status(400).send({ error: 'Invalid sessionId' });
+      return;
+    }
+    await session.transport.handlePostMessage(req.raw, reply.raw, req.body);
+  });
 
-app.get('/mcp', async (req, reply) => {
+  return app;
+}
+
+export async function startStdioServer(): Promise<void> {
+  validateEnv();
   const server = createMcpServer();
-  const transport = new SSEServerTransport('/mcp', reply.raw);
-  sseSessions.set(transport.sessionId, { server, transport });
-  transport.onclose = () => sseSessions.delete(transport.sessionId);
+  const transport = new StdioServerTransport();
+  isStdioTransport = true;
   await server.connect(transport);
-});
+  safeLog(server, 'info', 'HuliHealth MCP Server running on stdio');
+}
 
-app.post('/mcp', async (req, reply) => {
-  const sessionId = (req.query as any).sessionId as string;
-  const session = sseSessions.get(sessionId);
-  if (!session) {
-    reply.status(400).send({ error: 'Invalid sessionId' });
-    return;
-  }
-  await session.transport.handlePostMessage(req.raw, reply.raw, req.body);
-});
-
-app.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {
-  if (err) {
+export async function startHttpServer(port = PORT): Promise<void> {
+  validateEnv();
+  const app = buildHttpServer();
+  try {
+    await app.listen({ port, host: '0.0.0.0' });
+    console.log(`HuliHealth MCP listening on http://0.0.0.0:${port}`);
+  } catch (err) {
     app.log.error(err);
     process.exit(1);
   }
-  console.log(`Server listening at ${address}`);
-});
+}
+
+if (process.env.SSE_LOCAL === 'true') {
+  startHttpServer().catch((err) => {
+    console.error('Fatal error running server:', err);
+    process.exit(1);
+  });
+} else {
+  startStdioServer().catch((err) => {
+    console.error('Fatal error running server:', err);
+    process.exit(1);
+  });
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMcpServer, buildHttpServer } from '../src/index.js';
+import { tools } from '../src/mcp/toolRegistry.js';
+
+// Ensure required env vars for tests
+process.env.HULIHEALTH_API_KEY = 'test';
+process.env.HULI_ORG_ID = 'org';
+
+describe('MCP server', () => {
+  it('registers all tools', () => {
+    const server = createMcpServer() as any;
+    const registered = Object.keys(server._registeredTools);
+    const expected = tools.map((t) => t.name);
+    expect(registered.sort()).toEqual(expected.sort());
+  });
+
+  it('exposes tool metadata endpoint', async () => {
+    const app = buildHttpServer();
+    const res = await app.inject({ method: 'GET', url: '/mcp/tools' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const names = body.map((t: any) => t.name);
+    expect(names.sort()).toEqual(tools.map((t) => t.name).sort());
+    await app.close();
+  });
+
+  it('returns 400 for invalid SSE session', async () => {
+    const app = buildHttpServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/mcp?sessionId=missing',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- restructure `src/index.ts` to align with Firecrawl-style server architecture
- add validation for env variables and safe logging
- expose helper functions and start modes for SSE and stdio
- add comprehensive tests covering tool registration and endpoints

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6871083bee248325b55e58712a07096d