### PR TITLE
Convert repo to MCP-only server

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "axios": "^1.6.7",
     "dotenv": "^16.3.1",
-    "fastify": "^4.25.0",
     "zod": "^3.22.4",
     "@modelcontextprotocol/sdk": "latest"
   },

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -1,4 +1,3 @@
-import { FastifyInstance } from 'fastify';
 import {
   scheduleAppointment,
   ScheduleAppointmentParams,
@@ -101,23 +100,3 @@ export const tools: Tool<any, any>[] = [
   getCheckupCustomQuestions,
   getCheckupLastMenstrualCycle,
 ];
-
-export function registerToolRoutes(app: FastifyInstance): void {
-  app.get('/mcp/tools', async () =>
-    tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      schema: (t.parameters as any).toJSON?.() ?? {},
-    }))
-  );
-
-  app.post<{ Params: { tool: string }; Body: unknown }>('/mcp/tool/execute/:tool', async (req, reply) => {
-    const tool = tools.find((t) => t.name === req.params.tool);
-    if (!tool) return reply.status(404).send({ error: 'Tool not found' });
-    const parsed = tool.parameters.safeParse(req.body);
-    if (!parsed.success) return reply.status(400).send(parsed.error);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await tool.execute(parsed.data as any);
-    return result;
-  });
-}

--- a/src/services/huliClient.ts
+++ b/src/services/huliClient.ts
@@ -63,7 +63,6 @@ class HuliClient {
     if (!this.token) await this.authenticate();
     const headers = {
       Authorization: `Bearer ${this.token}`,
-@@ -29,28 +67,255 @@ class HuliClient {
       ...config.headers,
     };
     try {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { createMcpServer, buildHttpServer } from '../src/index.js';
+import { describe, it, expect } from 'vitest';
+import { createMcpServer } from '../src/index.js';
 import { tools } from '../src/mcp/toolRegistry.js';
 
 // Ensure required env vars for tests
@@ -14,24 +14,5 @@ describe('MCP server', () => {
     expect(registered.sort()).toEqual(expected.sort());
   });
 
-  it('exposes tool metadata endpoint', async () => {
-    const app = buildHttpServer();
-    const res = await app.inject({ method: 'GET', url: '/mcp/tools' });
-    expect(res.statusCode).toBe(200);
-    const body = res.json();
-    const names = body.map((t: any) => t.name);
-    expect(names.sort()).toEqual(tools.map((t) => t.name).sort());
-    await app.close();
-  });
-
-  it('returns 400 for invalid SSE session', async () => {
-    const app = buildHttpServer();
-    const res = await app.inject({
-      method: 'POST',
-      url: '/mcp?sessionId=missing',
-      payload: {},
-    });
-    expect(res.statusCode).toBe(400);
-    await app.close();
-  });
+  // The HTTP server has been removed in favor of pure MCP transports.
 });


### PR DESCRIPTION
## Summary
- strip Fastify dependency and remove HTTP routes
- register tools with MCP server only
- serve over stdio or SSE depending on env
- gate server startup behind `require.main`
- simplify tests for new server structure
- remove legacy Fastify route registration from tool registry

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871163b597c83258cd36144aba0352e