### PR TITLE
Migrate project to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   },
   "bin": {
     "hulihealth-mcp-dacs": "./bin/cli.js"
-  }
+  },
+  "type": "module"
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-// Usa require para compatibilidad con "module": "commonjs"
-const dotenv = require('dotenv');
-const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
-const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
-const http = require("node:http" );
-const { tools } = require('./mcp/toolRegistry'); 
+import dotenv from 'dotenv';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { tools } from './mcp/toolRegistry.js';
 
 dotenv.config();
 
@@ -12,15 +12,13 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 function validateEnv(): void {
   if (!process.env.HULIHEALTH_API_KEY || !process.env.HULI_ORG_ID) {
-    throw new Error(
-      'HULIHEALTH_API_KEY and HULI_ORG_ID environment variables must be set'
-    );
+    throw new Error('HULIHEALTH_API_KEY and HULI_ORG_ID environment variables must be set');
   }
 }
 
-function createMcpServer(): any {
+export function createMcpServer(): any {
   const server = new McpServer({ name: 'hulihealth-mcp-dacs', version: '1.0.0' });
-  
+
   for (const tool of tools) {
     server.registerTool(
       tool.name,
@@ -33,8 +31,8 @@ function createMcpServer(): any {
           const result = await tool.execute(params as any);
           return { content: [{ type: 'json', json: result }] };
         } catch (error: any) {
-            console.error(`[MCP Tool Error] Failed to execute tool '${tool.name}':`, error);
-            throw new Error(`Execution failed for tool ${tool.name}: ${error.message}`);
+          console.error(`[MCP Tool Error] Failed to execute tool '${tool.name}':`, error);
+          throw new Error(`Execution failed for tool ${tool.name}: ${error.message}`);
         }
       }
     );
@@ -42,7 +40,7 @@ function createMcpServer(): any {
   return server;
 }
 
-async function startStdioServer(): Promise<void> {
+export async function startStdioServer(): Promise<void> {
   console.error('[MCP Status] Initializing HuliHealth MCP Server in STDIO mode...');
   validateEnv();
   const server = createMcpServer();
@@ -51,13 +49,13 @@ async function startStdioServer(): Promise<void> {
   console.error('[MCP Status] HuliHealth MCP Server connected via STDIO. Ready for requests.');
 }
 
-async function startSseServer(port = PORT): Promise<void> {
+export async function startSseServer(port = PORT): Promise<void> {
   console.log(`[MCP Status] Initializing HuliHealth MCP Server in SSE mode on port ${port}...`);
   validateEnv();
-  const { SSEServerTransport } = require('@modelcontextprotocol/sdk/server/sse.js');
+  const { SSEServerTransport } = await import('@modelcontextprotocol/sdk/server/sse.js');
   const sseSessions = new Map<string, { server: any; transport: any }>();
 
-  const httpServer = http.createServer(async (req: any, res: any ) => {
+  const httpServer = http.createServer(async (req: any, res: any) => {
     if (req.method === 'GET' && req.url?.startsWith('/mcp')) {
       const server = createMcpServer();
       const transport = new SSEServerTransport('/mcp', res);
@@ -66,7 +64,7 @@ async function startSseServer(port = PORT): Promise<void> {
       await server.connect(transport);
       console.log(`[MCP Status] New SSE session created: ${transport.sessionId}`);
     } else if (req.method === 'POST' && req.url?.startsWith('/mcp')) {
-      const url = new URL(req.url, `http://${req.headers.host}` );
+      const url = new URL(req.url, `http://${req.headers.host}`);
       const sessionId = url.searchParams.get('sessionId');
       const session = sessionId ? sseSessions.get(sessionId) : undefined;
       if (!session) {
@@ -81,12 +79,12 @@ async function startSseServer(port = PORT): Promise<void> {
     }
   });
 
-  httpServer.listen(port, '0.0.0.0', ( ) => {
-    console.log(`[MCP Status] HuliHealth MCP SSE server listening on http://0.0.0.0:${port}` );
+  httpServer.listen(port, '0.0.0.0', () => {
+    console.log(`[MCP Status] HuliHealth MCP SSE server listening on http://0.0.0.0:${port}`);
   });
 }
 
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`\nHuliHealth MCP CLI\n\nUsage:\n  npx mcp-hulihealth [options]\n\nOptions:\n  --help, -h    Show this help\n  --sse         Start in SSE (HTTP) server mode (default: stdio)\n\nRequired environment variables:\n  HULIHEALTH_API_KEY   Your HuliHealth API Key\n  HULI_ORG_ID         Your HuliHealth Organization ID\n  PORT                (optional, for SSE mode. Default: 3000)\n`);
@@ -100,13 +98,9 @@ if (require.main === module) {
       startStdioServer();
     }
   } catch (err: any) {
-    console.error("[MCP FATAL ERROR] Failed to start MCP server:", err.message);
+    console.error('[MCP FATAL ERROR] Failed to start MCP server:', err.message);
     process.exit(1);
   }
 }
 
-module.exports = {
-  createMcpServer,
-  startStdioServer,
-  startSseServer
-};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from './mcp/toolRegistry.js';
+export * from './services/huliClient.js';
+export { createMcpServer, startStdioServer, startSseServer } from './cli.js';

--- a/src/mcp/toolRegistry.ts
+++ b/src/mcp/toolRegistry.ts
@@ -1,97 +1,94 @@
-const scheduleAppointment = require('../tools/scheduleAppointment');
-const cancelAppointment = require('../tools/cancelAppointment');
-const rescheduleAppointment = require('../tools/rescheduleAppointment');
-const getAvailability = require('../tools/getAvailability');
-const getAppointments = require('../tools/getAppointments');
-const getAppointmentById = require('../tools/getAppointmentById');
-const updateAppointment = require('../tools/updateAppointment');
-const confirmAppointment = require('../tools/confirmAppointment');
-const markNoShow = require('../tools/markNoShow');
-const getMostUsedAppointmentColors = require('../tools/getMostUsedAppointmentColors');
-const listAppointmentTags = require('../tools/listAppointmentTags');
-const getOrganization = require('../tools/getOrganization');
-const getDoctor = require('../tools/getDoctor');
-const getDoctorByUser = require('../tools/getDoctorByUser');
-const getDoctorClinicPhone = require('../tools/getDoctorClinicPhone');
-const getDoctorClinicAddress = require('../tools/getDoctorClinicAddress');
-const getPatient = require('../tools/getPatient');
-const getPatientByExternalId = require('../tools/getPatientByExternalId');
-const createPatientFile = require('../tools/createPatientFile');
-const listPatientFiles = require('../tools/listPatientFiles');
-const getPatientFile = require('../tools/getPatientFile');
-const uploadPatientDocument = require('../tools/uploadPatientDocument');
-const getClinics = require('../tools/getClinics');
-const getClinic = require('../tools/getClinic');
-const getMedicalRecord = require('../tools/getMedicalRecord');
-const getCheckup = require('../tools/getCheckup');
-const getCheckupNote = require('../tools/getCheckupNote');
-const getCheckupDiagnosis = require('../tools/getCheckupDiagnosis');
-const getCheckupPrescription = require('../tools/getCheckupPrescription');
-const getCheckupVitalSigns = require('../tools/getCheckupVitalSigns');
-const getCheckupLabProcedureRequest = require('../tools/getCheckupLabProcedureRequest');
-const getCheckupSuffering = require('../tools/getCheckupSuffering');
-const getCheckupReasonOfVisit = require('../tools/getCheckupReasonOfVisit');
-const getCheckupPhysicalNote = require('../tools/getCheckupPhysicalNote');
-const getCheckupAnthropometricData = require('../tools/getCheckupAnthropometricData');
-const getCheckupReviewOfSystems = require('../tools/getCheckupReviewOfSystems');
-const getCheckupSystematicExamination = require('../tools/getCheckupSystematicExamination');
-const getCheckupSleepPattern = require('../tools/getCheckupSleepPattern');
-const getCheckupBowelHabit = require('../tools/getCheckupBowelHabit');
-const getCheckupPlanNote = require('../tools/getCheckupPlanNote');
-const getCheckupCustomQuestions = require('../tools/getCheckupCustomQuestions');
-const getCheckupLastMenstrualCycle = require('../tools/getCheckupLastMenstrualCycle');
+import cancelAppointment from '../tools/cancelAppointment.js';
+import confirmAppointment from '../tools/confirmAppointment.js';
+import createPatientFile from '../tools/createPatientFile.js';
+import getAppointmentById from '../tools/getAppointmentById.js';
+import getAppointments from '../tools/getAppointments.js';
+import getAvailability from '../tools/getAvailability.js';
+import getCheckup from '../tools/getCheckup.js';
+import getCheckupAnthropometricData from '../tools/getCheckupAnthropometricData.js';
+import getCheckupBowelHabit from '../tools/getCheckupBowelHabit.js';
+import getCheckupCustomQuestions from '../tools/getCheckupCustomQuestions.js';
+import getCheckupDiagnosis from '../tools/getCheckupDiagnosis.js';
+import getCheckupLabProcedureRequest from '../tools/getCheckupLabProcedureRequest.js';
+import getCheckupLastMenstrualCycle from '../tools/getCheckupLastMenstrualCycle.js';
+import getCheckupNote from '../tools/getCheckupNote.js';
+import getCheckupPhysicalNote from '../tools/getCheckupPhysicalNote.js';
+import getCheckupPlanNote from '../tools/getCheckupPlanNote.js';
+import getCheckupPrescription from '../tools/getCheckupPrescription.js';
+import getCheckupReasonOfVisit from '../tools/getCheckupReasonOfVisit.js';
+import getCheckupReviewOfSystems from '../tools/getCheckupReviewOfSystems.js';
+import getCheckupSleepPattern from '../tools/getCheckupSleepPattern.js';
+import getCheckupSuffering from '../tools/getCheckupSuffering.js';
+import getCheckupSystematicExamination from '../tools/getCheckupSystematicExamination.js';
+import getCheckupVitalSigns from '../tools/getCheckupVitalSigns.js';
+import getClinic from '../tools/getClinic.js';
+import getClinics from '../tools/getClinics.js';
+import getDoctor from '../tools/getDoctor.js';
+import getDoctorByUser from '../tools/getDoctorByUser.js';
+import getDoctorClinicAddress from '../tools/getDoctorClinicAddress.js';
+import getDoctorClinicPhone from '../tools/getDoctorClinicPhone.js';
+import getMedicalRecord from '../tools/getMedicalRecord.js';
+import getMostUsedAppointmentColors from '../tools/getMostUsedAppointmentColors.js';
+import getOrganization from '../tools/getOrganization.js';
+import getPatient from '../tools/getPatient.js';
+import getPatientByExternalId from '../tools/getPatientByExternalId.js';
+import getPatientFile from '../tools/getPatientFile.js';
+import listAppointmentTags from '../tools/listAppointmentTags.js';
+import listPatientFiles from '../tools/listPatientFiles.js';
+import markNoShow from '../tools/markNoShow.js';
+import rescheduleAppointment from '../tools/rescheduleAppointment.js';
+import scheduleAppointment from '../tools/scheduleAppointment.js';
+import updateAppointment from '../tools/updateAppointment.js';
+import uploadPatientDocument from '../tools/uploadPatientDocument.js';
 
 const allTools = [
-  scheduleAppointment,
   cancelAppointment,
-  rescheduleAppointment,
-  getAvailability,
-  getAppointments,
-  getAppointmentById,
-  updateAppointment,
   confirmAppointment,
-  markNoShow,
-  getMostUsedAppointmentColors,
-  listAppointmentTags,
-  getOrganization,
+  createPatientFile,
+  getAppointmentById,
+  getAppointments,
+  getAvailability,
+  getCheckup,
+  getCheckupAnthropometricData,
+  getCheckupBowelHabit,
+  getCheckupCustomQuestions,
+  getCheckupDiagnosis,
+  getCheckupLabProcedureRequest,
+  getCheckupLastMenstrualCycle,
+  getCheckupNote,
+  getCheckupPhysicalNote,
+  getCheckupPlanNote,
+  getCheckupPrescription,
+  getCheckupReasonOfVisit,
+  getCheckupReviewOfSystems,
+  getCheckupSleepPattern,
+  getCheckupSuffering,
+  getCheckupSystematicExamination,
+  getCheckupVitalSigns,
+  getClinic,
+  getClinics,
   getDoctor,
   getDoctorByUser,
-  getDoctorClinicPhone,
   getDoctorClinicAddress,
+  getDoctorClinicPhone,
+  getMedicalRecord,
+  getMostUsedAppointmentColors,
+  getOrganization,
   getPatient,
   getPatientByExternalId,
-  createPatientFile,
-  listPatientFiles,
   getPatientFile,
+  listAppointmentTags,
+  listPatientFiles,
+  markNoShow,
+  rescheduleAppointment,
+  scheduleAppointment,
+  updateAppointment,
   uploadPatientDocument,
-  getClinics,
-  getClinic,
-  getMedicalRecord,
-  getCheckup,
-  getCheckupNote,
-  getCheckupDiagnosis,
-  getCheckupPrescription,
-  getCheckupVitalSigns,
-  getCheckupLabProcedureRequest,
-  getCheckupSuffering,
-  getCheckupReasonOfVisit,
-  getCheckupPhysicalNote,
-  getCheckupAnthropometricData,
-  getCheckupReviewOfSystems,
-  getCheckupSystematicExamination,
-  getCheckupSleepPattern,
-  getCheckupBowelHabit,
-  getCheckupPlanNote,
-  getCheckupCustomQuestions,
-  getCheckupLastMenstrualCycle,
 ];
-
 const validTools = allTools.filter(tool => tool && typeof tool.execute === 'function');
 
 if (validTools.length !== allTools.length) {
-    console.error("[MCP Registry Warning] Se detectaron y filtraron tools no válidos o mal formados. Revisa tus archivos de tools.");
+  console.error('[MCP Registry Warning] Se detectaron y filtraron tools no válidos o mal formados. Revisa tus archivos de tools.');
 }
+export const tools = validTools;
 
-module.exports = {
-  tools: validTools
-};

--- a/src/services/huliClient.ts
+++ b/src/services/huliClient.ts
@@ -37,7 +37,7 @@ import {
   CheckupPlanNote,
   CheckupCustomQuestions,
   CheckupLastMenstrualCycle,
-} from '../mcp/schema';
+} from '../mcp/schema.js';
 import * as dotenv from "dotenv";
 
 dotenv.config();

--- a/src/tools/cancelAppointment.ts
+++ b/src/tools/cancelAppointment.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Appointment, CancelAppointmentRequest } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Appointment, CancelAppointmentRequest } from '../mcp/schema.js';
 
 export const cancelAppointmentSchema = z.object({
   event_id: z.string(),
@@ -32,3 +32,4 @@ export const cancelAppointment = {
   },
 };
 export type CancelAppointmentTool = typeof cancelAppointment;
+export default cancelAppointment;

--- a/src/tools/confirmAppointment.ts
+++ b/src/tools/confirmAppointment.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Appointment } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Appointment } from '../mcp/schema.js';
 
 export const confirmAppointmentSchema = z.object({
   event_id: z.string(),
@@ -25,3 +25,4 @@ export const confirmAppointment = {
   },
 };
 export type ConfirmAppointmentTool = typeof confirmAppointment;
+export default confirmAppointment;

--- a/src/tools/createPatientFile.ts
+++ b/src/tools/createPatientFile.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { PatientFileRequest, PatientFileResponse } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { PatientFileRequest, PatientFileResponse } from '../mcp/schema.js';
 
 export const createPatientFileSchema = z.object({
   data: z.any(),
@@ -18,3 +18,4 @@ export const createPatientFile = {
   },
 };
 export type CreatePatientFileTool = typeof createPatientFile;
+export default createPatientFile;

--- a/src/tools/getAppointmentById.ts
+++ b/src/tools/getAppointmentById.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Appointment } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Appointment } from '../mcp/schema.js';
 
 export const getAppointmentByIdSchema = z.object({
   event_id: z.string(),
@@ -25,3 +25,4 @@ export const getAppointmentById = {
   },
 };
 export type GetAppointmentByIdTool = typeof getAppointmentById;
+export default getAppointmentById;

--- a/src/tools/getAppointments.ts
+++ b/src/tools/getAppointments.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { AppointmentList } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { AppointmentList } from '../mcp/schema.js';
 
 export const getAppointmentsSchema = z
   .object({
@@ -56,3 +56,4 @@ export const getAppointments = {
   },
 };
 export type GetAppointmentsTool = typeof getAppointments;
+export default getAppointments;

--- a/src/tools/getAvailability.ts
+++ b/src/tools/getAvailability.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { DoctorAvailabilityResponse } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { DoctorAvailabilityResponse } from '../mcp/schema.js';
 
 export const getAvailabilitySchema = z.object({
   doctor_id: z.string(),
@@ -32,3 +32,4 @@ export const getAvailability = {
   },
 };
 export type GetAvailabilityTool = typeof getAvailability;
+export default getAvailability;

--- a/src/tools/getCheckup.ts
+++ b/src/tools/getCheckup.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Checkup } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Checkup } from '../mcp/schema.js';
 
 export const getCheckupSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckup = {
   },
 };
 export type GetCheckupTool = typeof getCheckup;
+export default getCheckup;

--- a/src/tools/getCheckupAnthropometricData.ts
+++ b/src/tools/getCheckupAnthropometricData.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupAnthropometric } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupAnthropometric } from '../mcp/schema.js';
 
 export const getCheckupAnthropometricDataSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupAnthropometricData = {
   },
 };
 export type GetCheckupAnthropometricDataTool = typeof getCheckupAnthropometricData;
+export default getCheckupAnthropometricData;

--- a/src/tools/getCheckupBowelHabit.ts
+++ b/src/tools/getCheckupBowelHabit.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupBowelHabit } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupBowelHabit } from '../mcp/schema.js';
 
 export const getCheckupBowelHabitSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupBowelHabit = {
   },
 };
 export type GetCheckupBowelHabitTool = typeof getCheckupBowelHabit;
+export default getCheckupBowelHabit;

--- a/src/tools/getCheckupCustomQuestions.ts
+++ b/src/tools/getCheckupCustomQuestions.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupCustomQuestions } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupCustomQuestions } from '../mcp/schema.js';
 
 export const getCheckupCustomQuestionsSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupCustomQuestions = {
   },
 };
 export type GetCheckupCustomQuestionsTool = typeof getCheckupCustomQuestions;
+export default getCheckupCustomQuestions;

--- a/src/tools/getCheckupDiagnosis.ts
+++ b/src/tools/getCheckupDiagnosis.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupDiagnosis } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupDiagnosis } from '../mcp/schema.js';
 
 export const getCheckupDiagnosisSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupDiagnosis = {
   },
 };
 export type GetCheckupDiagnosisTool = typeof getCheckupDiagnosis;
+export default getCheckupDiagnosis;

--- a/src/tools/getCheckupLabProcedureRequest.ts
+++ b/src/tools/getCheckupLabProcedureRequest.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupLabProcedure } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupLabProcedure } from '../mcp/schema.js';
 
 export const getCheckupLabProcedureRequestSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupLabProcedureRequest = {
   },
 };
 export type GetCheckupLabProcedureRequestTool = typeof getCheckupLabProcedureRequest;
+export default getCheckupLabProcedureRequest;

--- a/src/tools/getCheckupLastMenstrualCycle.ts
+++ b/src/tools/getCheckupLastMenstrualCycle.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupLastMenstrualCycle } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupLastMenstrualCycle } from '../mcp/schema.js';
 
 export const getCheckupLastMenstrualCycleSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupLastMenstrualCycle = {
   },
 };
 export type GetCheckupLastMenstrualCycleTool = typeof getCheckupLastMenstrualCycle;
+export default getCheckupLastMenstrualCycle;

--- a/src/tools/getCheckupNote.ts
+++ b/src/tools/getCheckupNote.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupNote } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupNote } from '../mcp/schema.js';
 
 export const getCheckupNoteSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupNote = {
   },
 };
 export type GetCheckupNoteTool = typeof getCheckupNote;
+export default getCheckupNote;

--- a/src/tools/getCheckupPhysicalNote.ts
+++ b/src/tools/getCheckupPhysicalNote.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupPhysicalNote } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupPhysicalNote } from '../mcp/schema.js';
 
 export const getCheckupPhysicalNoteSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupPhysicalNote = {
   },
 };
 export type GetCheckupPhysicalNoteTool = typeof getCheckupPhysicalNote;
+export default getCheckupPhysicalNote;

--- a/src/tools/getCheckupPlanNote.ts
+++ b/src/tools/getCheckupPlanNote.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupPlanNote } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupPlanNote } from '../mcp/schema.js';
 
 export const getCheckupPlanNoteSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupPlanNote = {
   },
 };
 export type GetCheckupPlanNoteTool = typeof getCheckupPlanNote;
+export default getCheckupPlanNote;

--- a/src/tools/getCheckupPrescription.ts
+++ b/src/tools/getCheckupPrescription.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupPrescription } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupPrescription } from '../mcp/schema.js';
 
 export const getCheckupPrescriptionSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupPrescription = {
   },
 };
 export type GetCheckupPrescriptionTool = typeof getCheckupPrescription;
+export default getCheckupPrescription;

--- a/src/tools/getCheckupReasonOfVisit.ts
+++ b/src/tools/getCheckupReasonOfVisit.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupReasonOfVisit } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupReasonOfVisit } from '../mcp/schema.js';
 
 export const getCheckupReasonOfVisitSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupReasonOfVisit = {
   },
 };
 export type GetCheckupReasonOfVisitTool = typeof getCheckupReasonOfVisit;
+export default getCheckupReasonOfVisit;

--- a/src/tools/getCheckupReviewOfSystems.ts
+++ b/src/tools/getCheckupReviewOfSystems.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupReviewOfSystems } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupReviewOfSystems } from '../mcp/schema.js';
 
 export const getCheckupReviewOfSystemsSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupReviewOfSystems = {
   },
 };
 export type GetCheckupReviewOfSystemsTool = typeof getCheckupReviewOfSystems;
+export default getCheckupReviewOfSystems;

--- a/src/tools/getCheckupSleepPattern.ts
+++ b/src/tools/getCheckupSleepPattern.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupSleepPattern } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupSleepPattern } from '../mcp/schema.js';
 
 export const getCheckupSleepPatternSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupSleepPattern = {
   },
 };
 export type GetCheckupSleepPatternTool = typeof getCheckupSleepPattern;
+export default getCheckupSleepPattern;

--- a/src/tools/getCheckupSuffering.ts
+++ b/src/tools/getCheckupSuffering.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupSuffering } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupSuffering } from '../mcp/schema.js';
 
 export const getCheckupSufferingSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupSuffering = {
   },
 };
 export type GetCheckupSufferingTool = typeof getCheckupSuffering;
+export default getCheckupSuffering;

--- a/src/tools/getCheckupSystematicExamination.ts
+++ b/src/tools/getCheckupSystematicExamination.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupSystematicExamination } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupSystematicExamination } from '../mcp/schema.js';
 
 export const getCheckupSystematicExaminationSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupSystematicExamination = {
   },
 };
 export type GetCheckupSystematicExaminationTool = typeof getCheckupSystematicExamination;
+export default getCheckupSystematicExamination;

--- a/src/tools/getCheckupVitalSigns.ts
+++ b/src/tools/getCheckupVitalSigns.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CheckupVitalSigns } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CheckupVitalSigns } from '../mcp/schema.js';
 
 export const getCheckupVitalSignsSchema = z.object({
   event_id: z.string(),
@@ -17,3 +17,4 @@ export const getCheckupVitalSigns = {
   },
 };
 export type GetCheckupVitalSignsTool = typeof getCheckupVitalSigns;
+export default getCheckupVitalSigns;

--- a/src/tools/getClinic.ts
+++ b/src/tools/getClinic.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Clinic } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Clinic } from '../mcp/schema.js';
 
 export const getClinicSchema = z.object({
   clinic_id: z.string(),
@@ -17,3 +17,4 @@ export const getClinic = {
   },
 };
 export type GetClinicTool = typeof getClinic;
+export default getClinic;

--- a/src/tools/getClinics.ts
+++ b/src/tools/getClinics.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { ClinicList } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { ClinicList } from '../mcp/schema.js';
 
 export const getClinicsSchema = z.object({});
 
@@ -15,3 +15,4 @@ export const getClinics = {
   },
 };
 export type GetClinicsTool = typeof getClinics;
+export default getClinics;

--- a/src/tools/getDoctor.ts
+++ b/src/tools/getDoctor.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Doctor } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Doctor } from '../mcp/schema.js';
 
 export const getDoctorSchema = z.object({
   doctor_id: z.string(),
@@ -18,3 +18,4 @@ export const getDoctor = {
 };
 export type GetDoctorTool = typeof getDoctor;
 
+export default getDoctor;

--- a/src/tools/getDoctorByUser.ts
+++ b/src/tools/getDoctorByUser.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Doctor } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Doctor } from '../mcp/schema.js';
 
 export const getDoctorByUserSchema = z.object({
   user_id: z.string(),
@@ -18,3 +18,4 @@ export const getDoctorByUser = {
 };
 export type GetDoctorByUserTool = typeof getDoctorByUser;
 
+export default getDoctorByUser;

--- a/src/tools/getDoctorClinicAddress.ts
+++ b/src/tools/getDoctorClinicAddress.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { DoctorClinicAddress } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { DoctorClinicAddress } from '../mcp/schema.js';
 
 export const getDoctorClinicAddressSchema = z.object({
   doctor_id: z.string(),
@@ -19,3 +19,4 @@ export const getDoctorClinicAddress = {
 };
 export type GetDoctorClinicAddressTool = typeof getDoctorClinicAddress;
 
+export default getDoctorClinicAddress;

--- a/src/tools/getDoctorClinicPhone.ts
+++ b/src/tools/getDoctorClinicPhone.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { DoctorClinicPhone } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { DoctorClinicPhone } from '../mcp/schema.js';
 
 export const getDoctorClinicPhoneSchema = z.object({
   doctor_id: z.string(),
@@ -19,3 +19,4 @@ export const getDoctorClinicPhone = {
 };
 export type GetDoctorClinicPhoneTool = typeof getDoctorClinicPhone;
 
+export default getDoctorClinicPhone;

--- a/src/tools/getMedicalRecord.ts
+++ b/src/tools/getMedicalRecord.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { MedicalRecord } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { MedicalRecord } from '../mcp/schema.js';
 
 export const getMedicalRecordSchema = z.object({
   patient_id: z.string(),
@@ -18,3 +18,4 @@ export const getMedicalRecord = {
   },
 };
 export type GetMedicalRecordTool = typeof getMedicalRecord;
+export default getMedicalRecord;

--- a/src/tools/getMostUsedAppointmentColors.ts
+++ b/src/tools/getMostUsedAppointmentColors.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
+import { huliClient } from '../services/huliClient.js';
 
 export const getMostUsedAppointmentColorsSchema = z
   .object({
@@ -63,3 +63,4 @@ export const getMostUsedAppointmentColors = {
   },
 };
 export type GetMostUsedAppointmentColorsTool = typeof getMostUsedAppointmentColors;
+export default getMostUsedAppointmentColors;

--- a/src/tools/getOrganization.ts
+++ b/src/tools/getOrganization.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { OrganizationResponse } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { OrganizationResponse } from '../mcp/schema.js';
 
 export const getOrganizationSchema = z.object({
   expand: z.enum(['AUTHORIZATION']).optional(),
@@ -18,3 +18,4 @@ export const getOrganization = {
 };
 export type GetOrganizationTool = typeof getOrganization;
 
+export default getOrganization;

--- a/src/tools/getPatient.ts
+++ b/src/tools/getPatient.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Patient } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Patient } from '../mcp/schema.js';
 
 export const getPatientSchema = z.object({
   patient_file_id: z.string(),
@@ -17,3 +17,4 @@ export const getPatient = {
   },
 };
 export type GetPatientTool = typeof getPatient;
+export default getPatient;

--- a/src/tools/getPatientByExternalId.ts
+++ b/src/tools/getPatientByExternalId.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Patient } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Patient } from '../mcp/schema.js';
 
 export const getPatientByExternalIdSchema = z.object({
   external_id: z.string(),
@@ -17,3 +17,4 @@ export const getPatientByExternalId = {
   },
 };
 export type GetPatientByExternalIdTool = typeof getPatientByExternalId;
+export default getPatientByExternalId;

--- a/src/tools/getPatientFile.ts
+++ b/src/tools/getPatientFile.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { PatientFileResponse } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { PatientFileResponse } from '../mcp/schema.js';
 
 export const getPatientFileSchema = z.object({
   patient_file_id: z.string(),
@@ -17,3 +17,4 @@ export const getPatientFile = {
   },
 };
 export type GetPatientFileTool = typeof getPatientFile;
+export default getPatientFile;

--- a/src/tools/listAppointmentTags.ts
+++ b/src/tools/listAppointmentTags.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { AppointmentTagsResponse } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { AppointmentTagsResponse } from '../mcp/schema.js';
 
 export const listAppointmentTagsSchema = z.object({
   limit: z.number().int().optional(),
@@ -29,3 +29,4 @@ export const listAppointmentTags = {
   },
 };
 export type ListAppointmentTagsTool = typeof listAppointmentTags;
+export default listAppointmentTags;

--- a/src/tools/listPatientFiles.ts
+++ b/src/tools/listPatientFiles.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { PatientFileList } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { PatientFileList } from '../mcp/schema.js';
 
 export const listPatientFilesSchema = z.object({
   query: z.string().optional(),
@@ -19,3 +19,4 @@ export const listPatientFiles = {
   },
 };
 export type ListPatientFilesTool = typeof listPatientFiles;
+export default listPatientFiles;

--- a/src/tools/markNoShow.ts
+++ b/src/tools/markNoShow.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Appointment } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Appointment } from '../mcp/schema.js';
 
 export const markNoShowSchema = z.object({
   event_id: z.string(),
@@ -25,3 +25,4 @@ export const markNoShow = {
   },
 };
 export type MarkNoShowTool = typeof markNoShow;
+export default markNoShow;

--- a/src/tools/rescheduleAppointment.ts
+++ b/src/tools/rescheduleAppointment.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
+import { huliClient } from '../services/huliClient.js';
 import {
   Appointment,
   RescheduleAppointmentRequest,
   AppointmentList,
-} from '../mcp/schema';
+} from '../mcp/schema.js';
 
 export const rescheduleAppointmentSchema = z
   .object({
@@ -60,3 +60,4 @@ export const rescheduleAppointment = {
   },
 };
 export type RescheduleAppointmentTool = typeof rescheduleAppointment;
+export default rescheduleAppointment;

--- a/src/tools/scheduleAppointment.ts
+++ b/src/tools/scheduleAppointment.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { CreateAppointmentRequest, Appointment } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { CreateAppointmentRequest, Appointment } from '../mcp/schema.js';
 
 export const scheduleAppointmentSchema = z.object({
   id_doctor: z.number(),
@@ -46,3 +46,4 @@ export const scheduleAppointment = {
   },
 };
 export type ScheduleAppointmentTool = typeof scheduleAppointment;
+export default scheduleAppointment;

--- a/src/tools/updateAppointment.ts
+++ b/src/tools/updateAppointment.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { Appointment, UpdateAppointmentRequest } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { Appointment, UpdateAppointmentRequest } from '../mcp/schema.js';
 
 export const updateAppointmentSchema = z.object({
   event_id: z.string(),
@@ -37,3 +37,4 @@ export const updateAppointment = {
   },
 };
 export type UpdateAppointmentTool = typeof updateAppointment;
+export default updateAppointment;

--- a/src/tools/uploadPatientDocument.ts
+++ b/src/tools/uploadPatientDocument.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { huliClient } from '../services/huliClient';
-import { UploadDocumentRequest } from '../mcp/schema';
+import { huliClient } from '../services/huliClient.js';
+import { UploadDocumentRequest } from '../mcp/schema.js';
 
 export const uploadPatientDocumentSchema = z.object({
   patient_file_id: z.string(),
@@ -20,3 +20,4 @@ export const uploadPatientDocument = {
   },
 };
 export type UploadPatientDocumentTool = typeof uploadPatientDocument;
+export default uploadPatientDocument;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
+    "target": "ES2022",
+    "module": "NodeNext",
     "rootDir": "src",
     "outDir": "dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "NodeNext"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- enable ESM in `package.json` and `tsconfig.json`
- refactor CLI and services to use ES module syntax
- convert tool registry and all tools to default exports
- export project entry points from `src/index.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873cc3ad434832581fc86c36a1700ba