### PR TITLE
Add base class for MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ npx hulihealth-mcp-dacs           # STDIO mode
 npx hulihealth-mcp-dacs --sse     # SSE mode on port $PORT or 3000
 ```
 
+### Generating new tools
+
+Create new MCP tools with the `mcp-gen-tool` helper:
+
+```bash
+npm run mcp-gen-tool create-tool --name=<toolName>
+```
+
+The command scaffolds `src/tools/<toolName>.ts` with a basic template. After
+editing the file remember to register the tool in `src/mcp/toolRegistry.ts`.
+
 ### n8n Integration
 
 Example configuration to run the MCP from an n8n workflow:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
-  "name": "mcp-hulihealth",
-  "version": "1.0.0",
+  "name": "hulihealth-mcp-dacs",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-hulihealth",
-      "version": "1.0.0",
+      "name": "hulihealth-mcp-dacs",
+      "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "latest",
         "axios": "^1.6.7",
         "dotenv": "^16.3.1",
+        "validator": "^13.15.15",
         "zod": "^3.22.4"
       },
       "bin": {
-        "hulihealth-mcp": "bin/cli.js"
+        "hulihealth-mcp-dacs": "bin/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -4359,6 +4361,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "test": "vitest",
     "lint": "eslint",
     "format": "prettier --write \"src/**/*.ts\"",
-    "prod": "node dist/index.js"
+    "prod": "node dist/index.js",
+    "mcp-gen-tool": "node --loader ts-node/esm ./src/mcp-gen-tool.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",
     "axios": "^1.6.7",
     "dotenv": "^16.3.1",
+    "validator": "^13.15.15",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/scripts/generate-mcp-docs.ts
+++ b/scripts/generate-mcp-docs.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import { tools } from '../src/mcp/toolRegistry.js';
+
+interface ToolDoc {
+  name: string;
+  description: string;
+}
+
+const docs: ToolDoc[] = tools.map(t => ({
+  name: t.name,
+  description: t.description,
+}));
+
+const yaml = docs
+  .map(d => `- name: ${d.name}\n  description: ${d.description}`)
+  .join('\n');
+
+fs.writeFileSync('mcp.yaml', yaml);
+console.log('mcp.yaml generated');

--- a/src/mcp-gen-tool.ts
+++ b/src/mcp-gen-tool.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Simple CLI for scaffolding new MCP tools.
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+function printHelp() {
+  console.log(`Usage: mcp-gen-tool create-tool --name <toolName>`);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+  const options: Record<string, string> = {};
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const [key, value] = arg.replace(/^--/, '').split('=');
+      if (value !== undefined) {
+        options[key] = value;
+      } else {
+        options[key] = args[i + 1];
+        i++;
+      }
+    }
+  }
+  return { command, options };
+}
+
+async function createTool(name: string) {
+  if (!name) {
+    console.error('Error: tool name is required.');
+    process.exit(1);
+  }
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const srcToolsDir = path.resolve(__dirname, 'tools');
+  const filePath = path.join(srcToolsDir, `${name}.ts`);
+
+  try {
+    await fs.access(filePath);
+    console.error(`[mcp-gen-tool] Tool '${name}' already exists at ${filePath}`);
+    process.exit(1);
+  } catch {
+    // file does not exist
+  }
+
+  const inputSchemaName = `${name}InputSchema`;
+  const outputSchemaName = `${name}OutputSchema`;
+
+  const template = `import { z } from 'zod';
+import { huliClient } from '../services/huliClient.js';
+
+// Input Schema
+export const ${inputSchemaName} = z.object({
+  // exampleField: z.string().describe('Describe this parameter')
+}).describe('Input parameters for ${name}');
+
+// Output Schema
+export const ${outputSchemaName} = z.object({
+  // resultField: z.string().describe('Describe result field')
+}).describe('Result of ${name}');
+
+export async function execute(params: z.infer<typeof ${inputSchemaName}>) {
+  const validatedParams = ${inputSchemaName}.parse(params);
+
+  // Call HuliHealth API through huliClient
+  const result = await huliClient.${name}(validatedParams as any);
+
+  return ${outputSchemaName}.parse(result);
+}
+
+export const toolDefinition = {
+  name: '${name}',
+  description: 'TODO: Describe ${name}',
+  parameters: ${inputSchemaName},
+  execute,
+};
+
+export default toolDefinition;
+`;
+
+  await fs.writeFile(filePath, template);
+  console.log(`[mcp-gen-tool] Created new tool at ${filePath}`);
+  console.log('[mcp-gen-tool] Remember to register the tool in src/mcp/toolRegistry.ts');
+}
+
+async function main() {
+  const { command, options } = parseArgs();
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+  if (command === 'create-tool') {
+    const name = options.name;
+    if (!name) {
+      console.error('Error: --name is required');
+      printHelp();
+      process.exit(1);
+    }
+    await createTool(name);
+  } else {
+    console.error(`Unknown command: ${command}`);
+    printHelp();
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('[mcp-gen-tool] Failed:', err);
+  process.exit(1);
+});

--- a/src/mcp/baseTool.ts
+++ b/src/mcp/baseTool.ts
@@ -1,0 +1,24 @@
+import { ZodSchema } from 'zod';
+
+/**
+ * Base class that every MCP tool should extend.
+ * Provides input validation via Zod.
+ *
+ * @template I Input parameter type
+ * @template O Output result type
+ */
+export abstract class MCPTool<I, O> {
+  abstract execute(params: I): Promise<O>;
+  abstract getInputSchema(): ZodSchema<I>;
+  abstract getOutputSchema(): ZodSchema<O>;
+
+  /**
+   * Validates unknown parameters according to the input schema.
+   *
+   * @param params - Raw parameters received from the MCP runtime
+   * @returns The validated input object
+   */
+  validate(params: unknown): I {
+    return this.getInputSchema().parse(params);
+  }
+}

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Custom error thrown when the HuliHealth API returns an unexpected response.
+ */
+export class ApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * Error thrown on authentication problems.
+ */
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+/**
+ * Error thrown when tool input fails validation.
+ */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}

--- a/src/services/huliClient.ts
+++ b/src/services/huliClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Minimal wrapper around the HuliHealth HTTP API.
+ * Handles authentication and provides typed methods for all endpoints.
+ */
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import {
   CreateAppointmentRequest,
@@ -65,6 +69,10 @@ class HuliClient {
       Authorization: `Bearer ${this.token}`,
       ...config.headers,
     };
+  /**
+   * Makes an authenticated request to the HuliHealth API.
+   * Automatically refreshes the JWT if needed.
+   */
     try {
       const res = await this.client.request<T>({ ...config, headers });
       // Axios returns data property

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,8 @@
+import validator from 'validator';
+
+/**
+ * Escapes potentially unsafe user provided strings.
+ */
+export function sanitizeInput(input: string): string {
+  return validator.escape(input);
+}

--- a/test/baseTool.spec.ts
+++ b/test/baseTool.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { MCPTool } from '../src/mcp/baseTool.js';
+
+class EchoTool extends MCPTool<{ msg: string }, { result: string }> {
+  getInputSchema() {
+    return z.object({ msg: z.string() });
+  }
+  getOutputSchema() {
+    return z.object({ result: z.string() });
+  }
+  async execute(params: { msg: string }) {
+    return { result: params.msg };
+  }
+}
+
+describe('MCPTool validate', () => {
+  it('parses parameters', () => {
+    const t = new EchoTool();
+    const res = t.validate({ msg: 'hi' });
+    expect(res).toEqual({ msg: 'hi' });
+  });
+});


### PR DESCRIPTION
## Summary
- add `MCPTool` abstract class with built‑in Zod validation
- scaffold generator already documented for creating new tools
- introduce typed error classes and sanitization helper
- add fatal error handling and docs for CLI
- simple docs generator script and test for base class

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6875c98a42b08325bf5a72370711ce8d